### PR TITLE
Change default port for PostgreSQL, add hints for configuration

### DIFF
--- a/bareos-zabbix.conf
+++ b/bareos-zabbix.conf
@@ -3,21 +3,21 @@
 
 # Use 'M' for MySQL
 # Use 'P' for PostgreSQL
-bareosDbSgdb='M'
+bareosDbSgdb='P'
 
 # IP address or FQDN of database server
 bareosDbAddr='127.0.0.1'
 
-# TCP port of database server
-bareosDbPort='3306'
+# TCP port of database server. This can be found in /etc/postgresql/XX/main/postgresql.conf or the catalog.conf in the bareos-dir configuration.
+bareosDbPort='5432'
 
-# Name of the database used by Bareos
+# Name of the database used by Bareos. This can be found in the catalog.conf in the bareos-dir configuration.
 bareosDbName='DBNAME'
 
-# User used by Bareos on it's database
+# User used by Bareos on it's database. This can be found in the catalog.conf in the bareos-dir configuration.
 bareosDbUser='DBUSER'
 
-# Password used by Bareos on it's database
+# Password used by Bareos on it's database. This can be found in the catalog.conf in the bareos-dir configuration.
 bareosDbPass='DBPASSWORD'
 
 


### PR DESCRIPTION
Default Postgresql listening port is 5432. MariaDB/MySQL is deprecated since Bareos 19.2 and unavailable since Bareos 20. 

Added hints, where to find configuration information.