### PR TITLE
Fix Int division error

### DIFF
--- a/bareos-zabbix.bash
+++ b/bareos-zabbix.bash
@@ -80,7 +80,7 @@ $zabbixSender -z $zabbixSrvAddr -p $zabbixSrvPort -s $bareosClientName -k "bareo
 if [ $? -ne 0 ] ; then return=$(($return+16)) ; fi
 
 # Get Job compression rate from database and send it to Zabbix server
-bareosJobCompr=$($sql "select round(1-JobBytes/ReadBytes,2) from Job where JobId=$bareosJobId;" 2>/dev/null)
+bareosJobCompr=$($sql "select round(1.0-JobBytes/(ReadBytes+0.0),2) from Job where JobId=$bareosJobId;" 2>/dev/null)
 $zabbixSender -z $zabbixSrvAddr -p $zabbixSrvPort -s $bareosClientName -k "bareos.$level.job.compr" -o $bareosJobCompr >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+32)) ; fi
 


### PR DESCRIPTION
JobBytes and ReadBytes are stored as INT in the database. An INT/INT division in SQL will always result in an int. (Thus rounding the result to 0 or 1).  This fixes the issue, and results in a fraction value (like 0.83) like it was intended.